### PR TITLE
fix for passing comments to the connect component and displaying comment information

### DIFF
--- a/src/components/content/11-MainComponent.js
+++ b/src/components/content/11-MainComponent.js
@@ -21,6 +21,7 @@ const mapStateToProps = (state) => {
     tips: state.tips,
     tools: state.tools,
     collab: state.collab,
+    comments: state.comments
   };
 };
 

--- a/src/components/content/5-ConnectComponent.js
+++ b/src/components/content/5-ConnectComponent.js
@@ -83,7 +83,7 @@ function Connect(props) {
     fullComments = props.comments.map((comment) => {
       return (
           <div key={comment.id} className="col-md-5 m-1">
-            {props.comment}
+            {comment.name}, {comment.message}
           </div>
       );
     });


### PR DESCRIPTION
i used a console.log on line 80 of the connect component and saw that we were receiving undefined for props.comments so i checked where we were sending that prop and we were just missing a mapping in the main component